### PR TITLE
[TM-141] Pledge Created Confirmation Link

### DIFF
--- a/src/SFA.DAS.LevyTransferMatching.Web/Views/Pledges/Confirmation.cshtml
+++ b/src/SFA.DAS.LevyTransferMatching.Web/Views/Pledges/Confirmation.cshtml
@@ -18,7 +18,7 @@
 
                     <h2 class="govuk-heading-m">What happens next</h2>
 
-                    <p>Your pledge is now public and can be <a href="@Url.Action("Detail", "Opportunities", new { EncodedPledgeId = Model.EncodedPledgeId })">viewed online</a>.</p>
+                    <p>Your pledge is now public and can be <a href="@Url.Action("Index", "Opportunities")">viewed online</a>.</p>
 
                     <p>You can share your pledge link with organisations you work with to promote your pledge.</p>
 


### PR DESCRIPTION
Changes the "pledge created" confirmation page so that the "viewed online" link goes to the list of opportunities, instead of the created pledge/opportunity.