### PR TITLE
[TM-132] Confirmation Page for Declined Funds (Receiver)

### DIFF
--- a/src/SFA.DAS.LevyTransferMatching.Infrastructure/Services/ApplicationsService/ApplicationsService.cs
+++ b/src/SFA.DAS.LevyTransferMatching.Infrastructure/Services/ApplicationsService/ApplicationsService.cs
@@ -73,5 +73,25 @@ namespace SFA.DAS.LevyTransferMatching.Infrastructure.Services.ApplicationsServi
 
             return getAcceptedResponse;
         }
+
+        public async Task<GetDeclinedResponse> GetDeclined(long accountId, int applicationId)
+        {
+            var response = await _httpClient.GetAsync($"accounts/{accountId}/applications/{applicationId}/declined");
+
+            GetDeclinedResponse getDeclinedResponse = null;
+            if (response.IsSuccessStatusCode)
+            {
+                getDeclinedResponse = JsonConvert.DeserializeObject<GetDeclinedResponse>(await response.Content.ReadAsStringAsync());
+            }
+            else
+            {
+                if (response.StatusCode != HttpStatusCode.NotFound)
+                {
+                    response.EnsureSuccessStatusCode();
+                }
+            }
+
+            return getDeclinedResponse;
+        }
     }
 }

--- a/src/SFA.DAS.LevyTransferMatching.Infrastructure/Services/ApplicationsService/ApplicationsService.cs
+++ b/src/SFA.DAS.LevyTransferMatching.Infrastructure/Services/ApplicationsService/ApplicationsService.cs
@@ -83,12 +83,9 @@ namespace SFA.DAS.LevyTransferMatching.Infrastructure.Services.ApplicationsServi
             {
                 getDeclinedResponse = JsonConvert.DeserializeObject<GetDeclinedResponse>(await response.Content.ReadAsStringAsync());
             }
-            else
+            else if (response.StatusCode != HttpStatusCode.NotFound)
             {
-                if (response.StatusCode != HttpStatusCode.NotFound)
-                {
-                    response.EnsureSuccessStatusCode();
-                }
+                response.EnsureSuccessStatusCode();
             }
 
             return getDeclinedResponse;

--- a/src/SFA.DAS.LevyTransferMatching.Infrastructure/Services/ApplicationsService/IApplicationsService.cs
+++ b/src/SFA.DAS.LevyTransferMatching.Infrastructure/Services/ApplicationsService/IApplicationsService.cs
@@ -11,5 +11,6 @@ namespace SFA.DAS.LevyTransferMatching.Infrastructure.Services.ApplicationsServi
         Task<Types.GetApplicationResponse> GetApplication(long accountId, int applicationId, CancellationToken cancellationToken = default);
         Task SetApplicationAcceptance(SetApplicationAcceptanceRequest request, CancellationToken cancellationToken = default);
         Task<GetAcceptedResponse> GetAccepted(long accountId, int applicationId);
+        Task<GetDeclinedResponse> GetDeclined(long accountId, int applicationId);
     }
 }

--- a/src/SFA.DAS.LevyTransferMatching.Infrastructure/Services/ApplicationsService/Types/GetDeclinedResponse.cs
+++ b/src/SFA.DAS.LevyTransferMatching.Infrastructure/Services/ApplicationsService/Types/GetDeclinedResponse.cs
@@ -1,0 +1,8 @@
+﻿namespace SFA.DAS.LevyTransferMatching.Infrastructure.Services.ApplicationsService.Types
+{
+    public class GetDeclinedResponse
+    {
+        public string EmployerAccountName { get; set; }
+        public int OpportunityId { get; set; }
+    }
+}

--- a/src/SFA.DAS.LevyTransferMatching.Web.UnitTests/Controllers/ApplicationsControllerTests.cs
+++ b/src/SFA.DAS.LevyTransferMatching.Web.UnitTests/Controllers/ApplicationsControllerTests.cs
@@ -153,5 +153,45 @@ namespace SFA.DAS.LevyTransferMatching.Web.UnitTests.Controllers
             // Act/Assert
             Assert.ThrowsAsync<System.NotImplementedException>(() => _controller.Application(request));
         }
+
+        [Test]
+        public async Task GET_Declined_ApplicationExists_ReturnsViewAndModel()
+        {
+            // Arrange
+            var request = _fixture.Create<DeclinedRequest>();
+            _orchestrator
+                .Setup(x => x.GetDeclinedViewModel(request))
+                .ReturnsAsync(new DeclinedViewModel());
+
+            // Act
+            var actionResult = await _controller.Declined(request);
+            var viewResult = actionResult as ViewResult;
+            var model = viewResult.Model;
+            var declinedViewModel = model as DeclinedViewModel;
+
+            // Assert
+            Assert.NotNull(actionResult);
+            Assert.NotNull(viewResult);
+            Assert.NotNull(model);
+            Assert.NotNull(declinedViewModel);
+        }
+
+        [Test]
+        public async Task GET_Declined_ApplicationDoesntExist_ReturnsNotFound()
+        {
+            // Arrange
+            var request = _fixture.Create<DeclinedRequest>();
+            _orchestrator
+                .Setup(x => x.GetDeclinedViewModel(request))
+                .ReturnsAsync((DeclinedViewModel)null);
+
+            // Act
+            var actionResult = await _controller.Declined(request);
+            var notFoundResult = actionResult as NotFoundResult;
+
+            // Assert
+            Assert.NotNull(actionResult);
+            Assert.NotNull(notFoundResult);
+        }
     }
 }

--- a/src/SFA.DAS.LevyTransferMatching.Web.UnitTests/Controllers/ApplicationsControllerTests.cs
+++ b/src/SFA.DAS.LevyTransferMatching.Web.UnitTests/Controllers/ApplicationsControllerTests.cs
@@ -46,7 +46,7 @@ namespace SFA.DAS.LevyTransferMatching.Web.UnitTests.Controllers
             // Arrange
             var request = _fixture.Create<ApplicationRequest>();
             _orchestrator
-                .Setup(x => x.GetApplication(request))
+                .Setup(x => x.GetApplication(It.Is<ApplicationRequest>(y => y == request)))
                 .ReturnsAsync(new ApplicationViewModel());
 
             // Act
@@ -68,7 +68,7 @@ namespace SFA.DAS.LevyTransferMatching.Web.UnitTests.Controllers
             // Arrange
             var request = _fixture.Create<ApplicationRequest>();
             _orchestrator
-                .Setup(x => x.GetApplication(request))
+                .Setup(x => x.GetApplication(It.Is<ApplicationRequest>(y => y == request)))
                 .ReturnsAsync((ApplicationViewModel)null);
 
             // Act
@@ -86,7 +86,7 @@ namespace SFA.DAS.LevyTransferMatching.Web.UnitTests.Controllers
             // Arrange
             var request = _fixture.Create<AcceptedRequest>();
             _orchestrator
-                .Setup(x => x.GetAcceptedViewModel(request))
+                .Setup(x => x.GetAcceptedViewModel(It.Is<AcceptedRequest>(y => y == request)))
                 .ReturnsAsync(new AcceptedViewModel());
 
             // Act
@@ -108,7 +108,7 @@ namespace SFA.DAS.LevyTransferMatching.Web.UnitTests.Controllers
             // Arrange
             var request = _fixture.Create<AcceptedRequest>();
             _orchestrator
-                .Setup(x => x.GetAcceptedViewModel(request))
+                .Setup(x => x.GetAcceptedViewModel(It.Is<AcceptedRequest>(y => y == request)))
                 .ReturnsAsync((AcceptedViewModel)null);
 
             // Act
@@ -168,7 +168,7 @@ namespace SFA.DAS.LevyTransferMatching.Web.UnitTests.Controllers
             // Arrange
             var request = _fixture.Create<DeclinedRequest>();
             _orchestrator
-                .Setup(x => x.GetDeclinedViewModel(request))
+                .Setup(x => x.GetDeclinedViewModel(It.Is<DeclinedRequest>(y => y == request)))
                 .ReturnsAsync(new DeclinedViewModel());
 
             // Act
@@ -190,7 +190,7 @@ namespace SFA.DAS.LevyTransferMatching.Web.UnitTests.Controllers
             // Arrange
             var request = _fixture.Create<DeclinedRequest>();
             _orchestrator
-                .Setup(x => x.GetDeclinedViewModel(request))
+                .Setup(x => x.GetDeclinedViewModel(It.Is<DeclinedRequest>(y => y == request)))
                 .ReturnsAsync((DeclinedViewModel)null);
 
             // Act

--- a/src/SFA.DAS.LevyTransferMatching.Web.UnitTests/Orchestrators/ApplicationsOrchestratorTests.cs
+++ b/src/SFA.DAS.LevyTransferMatching.Web.UnitTests/Orchestrators/ApplicationsOrchestratorTests.cs
@@ -169,6 +169,46 @@ namespace SFA.DAS.LevyTransferMatching.Web.UnitTests.Orchestrators
             Assert.IsNull(viewModel);
         }
 
+        [Test]
+        public async Task GetDeclinedViewModel_ApplicationExists_ReturnsViewModel()
+        {
+            // Arrange
+            var request = _fixture.Create<DeclinedRequest>();
+            var response = _fixture.Create<GetDeclinedResponse>();
+            var encodedPledgeId = _fixture.Create<string>();
+
+            _mockApplicationsService
+                .Setup(x => x.GetDeclined(It.Is<long>(y => y == request.AccountId), It.Is<int>(y => y == request.ApplicationId)))
+                .ReturnsAsync(response);
+
+            _mockEncodingService
+                .Setup(x => x.Encode(It.Is<long>(y => y == response.OpportunityId), It.Is<EncodingType>(y => y == EncodingType.PledgeId)))
+                .Returns(encodedPledgeId);
+
+            // Act
+            var viewModel = await _applicationsOrchestrator.GetDeclinedViewModel(request);
+
+            // Assert
+            Assert.IsNotNull(viewModel);
+            Assert.AreEqual($"{response.EmployerAccountName} ({encodedPledgeId})", viewModel.EmployerNameAndReference);
+        }
+
+        [Test]
+        public async Task GetDeclinedViewModel_ApplicationDoesntExist_ReturnsNull()
+        {
+            // Arrange
+            var request = _fixture.Create<DeclinedRequest>();
+
+            _mockApplicationsService
+                .Setup(x => x.GetDeclined(It.Is<long>(y => y == request.AccountId), It.Is<int>(y => y == request.ApplicationId)))
+                .ReturnsAsync((GetDeclinedResponse)null);
+
+            // Act
+            var viewModel = await _applicationsOrchestrator.GetDeclinedViewModel(request);
+
+            // Assert
+            Assert.IsNull(viewModel);
+        }
 
         [Test]
         public async Task GetApplicationViewModel_IsOwnerAndTransactorAndStatusEqualsApproved_ReturnsViewModelWithCanAcceptFunding()

--- a/src/SFA.DAS.LevyTransferMatching.Web/Controllers/ApplicationsController.cs
+++ b/src/SFA.DAS.LevyTransferMatching.Web/Controllers/ApplicationsController.cs
@@ -72,5 +72,19 @@ namespace SFA.DAS.LevyTransferMatching.Web.Controllers
 
             return NotFound();
         }
+
+        [HttpGet]
+        [Route("/accounts/{encodedAccountId}/applications/{encodedApplicationId}/declined")]
+        public async Task<IActionResult> Declined(DeclinedRequest request)
+        {
+            var viewModel = await _applicationsOrchestrator.GetDeclinedViewModel(request);
+
+            if (viewModel != null)
+            {
+                return View(viewModel);
+            }
+
+            return NotFound();
+        }
     }
 }

--- a/src/SFA.DAS.LevyTransferMatching.Web/Controllers/ApplicationsController.cs
+++ b/src/SFA.DAS.LevyTransferMatching.Web/Controllers/ApplicationsController.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using SFA.DAS.LevyTransferMatching.Web.Attributes;

--- a/src/SFA.DAS.LevyTransferMatching.Web/Models/Applications/DeclinedRequest.cs
+++ b/src/SFA.DAS.LevyTransferMatching.Web/Models/Applications/DeclinedRequest.cs
@@ -1,0 +1,15 @@
+﻿using SFA.DAS.LevyTransferMatching.Web.Attributes;
+
+namespace SFA.DAS.LevyTransferMatching.Web.Models.Applications
+{
+    public class DeclinedRequest
+    {
+        public string EncodedAccountId { get; set; }
+        [AutoDecode(nameof(EncodedAccountId), Encoding.EncodingType.AccountId)]
+        public long AccountId { get; set; }
+
+        public string EncodedApplicationId { get; set; }
+        [AutoDecode(nameof(EncodedApplicationId), Encoding.EncodingType.PledgeApplicationId)]
+        public int ApplicationId { get; set; }
+    }
+}

--- a/src/SFA.DAS.LevyTransferMatching.Web/Models/Applications/DeclinedViewModel.cs
+++ b/src/SFA.DAS.LevyTransferMatching.Web/Models/Applications/DeclinedViewModel.cs
@@ -1,0 +1,7 @@
+﻿namespace SFA.DAS.LevyTransferMatching.Web.Models.Applications
+{
+    public class DeclinedViewModel : DeclinedRequest
+    {
+        public string EmployerNameAndReference { get; set; }
+    }
+}

--- a/src/SFA.DAS.LevyTransferMatching.Web/Orchestrators/ApplicationsOrchestrator.cs
+++ b/src/SFA.DAS.LevyTransferMatching.Web/Orchestrators/ApplicationsOrchestrator.cs
@@ -148,5 +148,24 @@ namespace SFA.DAS.LevyTransferMatching.Web.Orchestrators
                 EmployerNameAndReference = $"{result.EmployerAccountName} ({encodedPledgeId})",
             };
         }
+
+        public async Task<DeclinedViewModel> GetDeclinedViewModel(DeclinedRequest request)
+        {
+            var result = await _applicationsService.GetDeclined(request.AccountId, request.ApplicationId);
+
+            if (result == null)
+            {
+                return null;
+            }
+
+            var encodedPledgeId = _encodingService.Encode(result.OpportunityId, EncodingType.PledgeId);
+
+            return new DeclinedViewModel()
+            {
+                EncodedAccountId = request.EncodedAccountId,
+                EncodedApplicationId = request.EncodedApplicationId,
+                EmployerNameAndReference = $"{result.EmployerAccountName} ({encodedPledgeId})",
+            };
+        }
     }
 }

--- a/src/SFA.DAS.LevyTransferMatching.Web/Orchestrators/IApplicationsOrchestrator.cs
+++ b/src/SFA.DAS.LevyTransferMatching.Web/Orchestrators/IApplicationsOrchestrator.cs
@@ -10,5 +10,6 @@ namespace SFA.DAS.LevyTransferMatching.Web.Orchestrators
         Task<ApplicationViewModel> GetApplication(ApplicationRequest request);
         Task SetApplicationAcceptance(ApplicationPostRequest request);
         Task<AcceptedViewModel> GetAcceptedViewModel(AcceptedRequest request);
+        Task<DeclinedViewModel> GetDeclinedViewModel(DeclinedRequest request);
     }
 }

--- a/src/SFA.DAS.LevyTransferMatching.Web/Views/Applications/Declined.cshtml
+++ b/src/SFA.DAS.LevyTransferMatching.Web/Views/Applications/Declined.cshtml
@@ -17,10 +17,9 @@
 
                 <h2 class="govuk-heading-m ">What happens next</h2>
 
-                <p>Your transfer of funds from <strong>@Model.EmployerNameAndReference</strong> has been declined. You can apply to another opportunity.</p>
+                <p class="govuk-!-margin-bottom-0">Your transfer of funds from <strong>@Model.EmployerNameAndReference</strong> has been declined. You can apply to another opportunity.</p>
 
-                <p>
-                    <br />
+                <p class="govuk-!-margin-top-1">
                     <a href="@Url.Action("Index", "Opportunities")" class="govuk-link">View other opportunities</a>
                     <br>
                     or

--- a/src/SFA.DAS.LevyTransferMatching.Web/Views/Applications/Declined.cshtml
+++ b/src/SFA.DAS.LevyTransferMatching.Web/Views/Applications/Declined.cshtml
@@ -1,0 +1,35 @@
+﻿@model SFA.DAS.LevyTransferMatching.Web.Models.Applications.DeclinedViewModel
+@inject SFA.DAS.EmployerUrlHelper.ILinkGenerator LinkGenerator
+
+@{
+    ViewData["Title"] = "You have successfully accepted a transfer";
+}
+
+<main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content">
+    <div class="govuk-width-container">
+
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+
+                <div class="govuk-panel govuk-panel--confirmation application-complete govuk-!-margin-bottom-9">
+                    <h1 class="govuk-panel__title">You have successfully declined a transfer of funds</h1>
+                </div>
+
+                <h2 class="govuk-heading-m ">What happens next</h2>
+
+                <p>Your transfer of funds from <strong>@Model.EmployerNameAndReference</strong> has been declined. You can apply to another opportunity.</p>
+
+                <p>
+                    <br />
+                    <a href="@Url.Action("Opportunities", "Index")" class="govuk-link">View other opportunities</a>
+                    <br>
+                    or
+                    <br>
+                    <a href="@LinkGenerator.AccountsLink($"accounts/{Model.EncodedAccountId}/teams")" class="govuk-link">Return to my account</a>
+                </p>
+
+            </div>
+        </div>
+
+    </div>
+</main>

--- a/src/SFA.DAS.LevyTransferMatching.Web/Views/Applications/Declined.cshtml
+++ b/src/SFA.DAS.LevyTransferMatching.Web/Views/Applications/Declined.cshtml
@@ -21,7 +21,7 @@
 
                 <p>
                     <br />
-                    <a href="@Url.Action("Opportunities", "Index")" class="govuk-link">View other opportunities</a>
+                    <a href="@Url.Action("Index", "Opportunities")" class="govuk-link">View other opportunities</a>
                     <br>
                     or
                     <br>

--- a/src/SFA.DAS.LevyTransferMatching.Web/Views/Shared/_ApplicationCanAcceptFundingPartial.cshtml
+++ b/src/SFA.DAS.LevyTransferMatching.Web/Views/Shared/_ApplicationCanAcceptFundingPartial.cshtml
@@ -47,8 +47,10 @@
                 <div class="govuk-radios__conditional" id="decline-content">
                     <div class="govuk-form-group">
                         <fieldset class="govuk-fieldset">
+                            <legend class="govuk-fieldset__legend">I confirm that:</legend>
+
                             <span id="ConfirmWithdrawal" das-validation-for="ConfirmWithdrawal" class="govuk-error-message"></span>
-                            <checkbox asp-for="ConfirmWithdrawal" label="I confirm I want to decline the funding and withdraw the application" aria-controls="ConfirmWithdrawl" css-class="govuk-checkboxes govuk-checkboxes--small">
+                            <checkbox asp-for="ConfirmWithdrawal" label="I want to decline the funding and withdraw the application" aria-controls="ConfirmWithdrawl" css-class="govuk-checkboxes govuk-checkboxes--small">
 
                             </checkbox>
 


### PR DESCRIPTION
The confirmation page for declined funds, from the receiver's perspective.

Note: targets `TM-54-Decline-Funding-For-Approved-Applications`.

See also:

* https://github.com/SkillsFundingAgency/das-apim-endpoints/pull/532