### PR TITLE
[TM-194] Confirmation Page for Withdrawn Application (Receiver)

### DIFF
--- a/src/SFA.DAS.LevyTransferMatching.Infrastructure/Services/ApplicationsService/ApplicationsService.cs
+++ b/src/SFA.DAS.LevyTransferMatching.Infrastructure/Services/ApplicationsService/ApplicationsService.cs
@@ -73,5 +73,22 @@ namespace SFA.DAS.LevyTransferMatching.Infrastructure.Services.ApplicationsServi
 
             return getAcceptedResponse;
         }
+
+        public async Task<GetWithdrawnResponse> GetWithdrawn(long accountId, int applicationId)
+        {
+            var response = await _httpClient.GetAsync($"accounts/{accountId}/applications/{applicationId}/withdrawn");
+
+            GetWithdrawnResponse getWithdrawnResponse = null;
+            if (response.IsSuccessStatusCode)
+            {
+                getWithdrawnResponse = JsonConvert.DeserializeObject<GetWithdrawnResponse>(await response.Content.ReadAsStringAsync());
+            }
+            else if (response.StatusCode != HttpStatusCode.NotFound)
+            {
+                response.EnsureSuccessStatusCode();
+            }
+
+            return getWithdrawnResponse;
+        }
     }
 }

--- a/src/SFA.DAS.LevyTransferMatching.Infrastructure/Services/ApplicationsService/IApplicationsService.cs
+++ b/src/SFA.DAS.LevyTransferMatching.Infrastructure/Services/ApplicationsService/IApplicationsService.cs
@@ -11,5 +11,6 @@ namespace SFA.DAS.LevyTransferMatching.Infrastructure.Services.ApplicationsServi
         Task<Types.GetApplicationResponse> GetApplication(long accountId, int applicationId, CancellationToken cancellationToken = default);
         Task SetApplicationAcceptance(SetApplicationAcceptanceRequest request, CancellationToken cancellationToken = default);
         Task<GetAcceptedResponse> GetAccepted(long accountId, int applicationId);
+        Task<GetWithdrawnResponse> GetWithdrawn(long accountId, int applicationId);
     }
 }

--- a/src/SFA.DAS.LevyTransferMatching.Infrastructure/Services/ApplicationsService/Types/GetWithdrawnResponse.cs
+++ b/src/SFA.DAS.LevyTransferMatching.Infrastructure/Services/ApplicationsService/Types/GetWithdrawnResponse.cs
@@ -1,0 +1,8 @@
+﻿namespace SFA.DAS.LevyTransferMatching.Infrastructure.Services.ApplicationsService.Types
+{
+    public class GetWithdrawnResponse
+    {
+        public string EmployerAccountName { get; set; }
+        public int OpportunityId { get; set; }
+    }
+}

--- a/src/SFA.DAS.LevyTransferMatching.Web.UnitTests/Controllers/ApplicationsControllerTests.cs
+++ b/src/SFA.DAS.LevyTransferMatching.Web.UnitTests/Controllers/ApplicationsControllerTests.cs
@@ -153,5 +153,45 @@ namespace SFA.DAS.LevyTransferMatching.Web.UnitTests.Controllers
             // Act/Assert
             Assert.ThrowsAsync<System.NotImplementedException>(() => _controller.Application(request));
         }
+
+        [Test]
+        public async Task GET_Withdrawn_ApplicationExists_ReturnsViewAndModel()
+        {
+            // Arrange
+            var request = _fixture.Create<WithdrawnRequest>();
+            _orchestrator
+                .Setup(x => x.GetWithdrawnViewModel(It.Is<WithdrawnRequest>(y => y == request)))
+                .ReturnsAsync(new WithdrawnViewModel());
+
+            // Act
+            var actionResult = await _controller.Withdrawn(request);
+            var viewResult = actionResult as ViewResult;
+            var model = viewResult.Model;
+            var withdrawnViewModel = model as WithdrawnViewModel;
+
+            // Assert
+            Assert.NotNull(actionResult);
+            Assert.NotNull(viewResult);
+            Assert.NotNull(model);
+            Assert.NotNull(withdrawnViewModel);
+        }
+
+        [Test]
+        public async Task GET_Withdrawn_ApplicationDoesntExist_ReturnsNotFound()
+        {
+            // Arrange
+            var request = _fixture.Create<WithdrawnRequest>();
+            _orchestrator
+                .Setup(x => x.GetWithdrawnViewModel(It.Is<WithdrawnRequest>(y => y == request)))
+                .ReturnsAsync((WithdrawnViewModel)null);
+
+            // Act
+            var actionResult = await _controller.Withdrawn(request);
+            var notFoundResult = actionResult as NotFoundResult;
+
+            // Assert
+            Assert.NotNull(actionResult);
+            Assert.NotNull(notFoundResult);
+        }
     }
 }

--- a/src/SFA.DAS.LevyTransferMatching.Web.UnitTests/Orchestrators/ApplicationsOrchestratorTests.cs
+++ b/src/SFA.DAS.LevyTransferMatching.Web.UnitTests/Orchestrators/ApplicationsOrchestratorTests.cs
@@ -225,6 +225,48 @@ namespace SFA.DAS.LevyTransferMatching.Web.UnitTests.Orchestrators
         }
 
 
+        [Test]
+        public async Task GetWithdrawnViewModel_ApplicationExists_ReturnsViewModel()
+        {
+            // Arrange
+            var request = _fixture.Create<WithdrawnRequest>();
+            var response = _fixture.Create<GetWithdrawnResponse>();
+            var encodedPledgeId = _fixture.Create<string>();
+
+            _mockApplicationsService
+                .Setup(x => x.GetWithdrawn(It.Is<long>(y => y == request.AccountId), It.Is<int>(y => y == request.ApplicationId)))
+                .ReturnsAsync(response);
+
+            _mockEncodingService
+                .Setup(x => x.Encode(It.Is<long>(y => y == response.OpportunityId), It.Is<EncodingType>(y => y == EncodingType.PledgeId)))
+                .Returns(encodedPledgeId);
+
+            // Act
+            var viewModel = await _applicationsOrchestrator.GetWithdrawnViewModel(request);
+
+            // Assert
+            Assert.IsNotNull(viewModel);
+            Assert.AreEqual($"{response.EmployerAccountName} ({encodedPledgeId})", viewModel.EmployerNameAndReference);
+        }
+
+        [Test]
+        public async Task GetWithdrawnViewModel_ApplicationDoesntExist_ReturnsNull()
+        {
+            // Arrange
+            var request = _fixture.Create<WithdrawnRequest>();
+
+            _mockApplicationsService
+                .Setup(x => x.GetWithdrawn(It.Is<long>(y => y == request.AccountId), It.Is<int>(y => y == request.ApplicationId)))
+                .ReturnsAsync((GetWithdrawnResponse)null);
+
+            // Act
+            var viewModel = await _applicationsOrchestrator.GetWithdrawnViewModel(request);
+
+            // Assert
+            Assert.IsNull(viewModel);
+        }
+
+
         private static void SetCorrectDatesForGetEffectiveFundingLine(GetApplicationResponse response)
         {
             // Because -

--- a/src/SFA.DAS.LevyTransferMatching.Web/Controllers/ApplicationsController.cs
+++ b/src/SFA.DAS.LevyTransferMatching.Web/Controllers/ApplicationsController.cs
@@ -62,7 +62,7 @@ namespace SFA.DAS.LevyTransferMatching.Web.Controllers
 
             if (request.SelectedAction == ApplicationViewModel.ApprovalAction.Withdraw)
             {
-                return View("Withdrawn");
+                return Redirect($"/accounts/{request.EncodedAccountId}/applications/{request.EncodedApplicationId}/withdrawn");
             }
             
             // TODO: Implemnentation of decline journey
@@ -74,6 +74,20 @@ namespace SFA.DAS.LevyTransferMatching.Web.Controllers
         public async Task<IActionResult> Accepted(AcceptedRequest request)
         {
             var viewModel = await _applicationsOrchestrator.GetAcceptedViewModel(request);
+
+            if (viewModel != null)
+            {
+                return View(viewModel);
+            }
+
+            return NotFound();
+        }
+
+        [HttpGet]
+        [Route("/accounts/{encodedAccountId}/applications/{encodedApplicationId}/withdrawn")]
+        public async Task<IActionResult> Withdrawn(WithdrawnRequest request)
+        {
+            var viewModel = await _applicationsOrchestrator.GetWithdrawnViewModel(request);
 
             if (viewModel != null)
             {

--- a/src/SFA.DAS.LevyTransferMatching.Web/Models/Applications/WithdrawnRequest.cs
+++ b/src/SFA.DAS.LevyTransferMatching.Web/Models/Applications/WithdrawnRequest.cs
@@ -1,0 +1,15 @@
+﻿using SFA.DAS.LevyTransferMatching.Web.Attributes;
+
+namespace SFA.DAS.LevyTransferMatching.Web.Models.Applications
+{
+    public class WithdrawnRequest
+    {
+        public string EncodedAccountId { get; set; }
+        [AutoDecode(nameof(EncodedAccountId), Encoding.EncodingType.AccountId)]
+        public long AccountId { get; set; }
+
+        public string EncodedApplicationId { get; set; }
+        [AutoDecode(nameof(EncodedApplicationId), Encoding.EncodingType.PledgeApplicationId)]
+        public int ApplicationId { get; set; }
+    }
+}

--- a/src/SFA.DAS.LevyTransferMatching.Web/Models/Applications/WithdrawnViewModel.cs
+++ b/src/SFA.DAS.LevyTransferMatching.Web/Models/Applications/WithdrawnViewModel.cs
@@ -1,0 +1,7 @@
+﻿namespace SFA.DAS.LevyTransferMatching.Web.Models.Applications
+{
+    public class WithdrawnViewModel : WithdrawnRequest
+    {
+        public string EmployerNameAndReference { get; set; }
+    }
+}

--- a/src/SFA.DAS.LevyTransferMatching.Web/Orchestrators/ApplicationsOrchestrator.cs
+++ b/src/SFA.DAS.LevyTransferMatching.Web/Orchestrators/ApplicationsOrchestrator.cs
@@ -150,5 +150,24 @@ namespace SFA.DAS.LevyTransferMatching.Web.Orchestrators
                 EmployerNameAndReference = $"{result.EmployerAccountName} ({encodedPledgeId})",
             };
         }
+
+        public async Task<WithdrawnViewModel> GetWithdrawnViewModel(WithdrawnRequest request)
+        {
+            var result = await _applicationsService.GetWithdrawn(request.AccountId, request.ApplicationId);
+
+            if (result == null)
+            {
+                return null;
+            }
+
+            var encodedPledgeId = _encodingService.Encode(result.OpportunityId, EncodingType.PledgeId);
+
+            return new WithdrawnViewModel()
+            {
+                EncodedAccountId = request.EncodedAccountId,
+                EncodedApplicationId = request.EncodedApplicationId,
+                EmployerNameAndReference = $"{result.EmployerAccountName} ({encodedPledgeId})",
+            };
+        }
     }
 }

--- a/src/SFA.DAS.LevyTransferMatching.Web/Orchestrators/IApplicationsOrchestrator.cs
+++ b/src/SFA.DAS.LevyTransferMatching.Web/Orchestrators/IApplicationsOrchestrator.cs
@@ -10,5 +10,6 @@ namespace SFA.DAS.LevyTransferMatching.Web.Orchestrators
         Task<ApplicationViewModel> GetApplication(ApplicationRequest request);
         Task SetApplicationAcceptance(ApplicationPostRequest request);
         Task<AcceptedViewModel> GetAcceptedViewModel(AcceptedRequest request);
+        Task<WithdrawnViewModel> GetWithdrawnViewModel(WithdrawnRequest request);
     }
 }

--- a/src/SFA.DAS.LevyTransferMatching.Web/Views/Applications/Withdrawn.cshtml
+++ b/src/SFA.DAS.LevyTransferMatching.Web/Views/Applications/Withdrawn.cshtml
@@ -19,12 +19,12 @@
 
                 <p class="govuk-!-margin-bottom-0">Your application to <strong>@Model.EmployerNameAndReference</strong> has been withdrawn. You can apply to another opportunity.</p>
 
-                <p class="govuk-!-margin-top-1">
+                <p class="govuk-!-margin-top-2">
                     <a href="@Url.Action("Index", "Opportunities")" class="govuk-link">View other opportunities</a>
                     <br>
                     or
                     <br>
-                    <a href="@LinkGenerator.AccountsLink($"accounts/{Model.EncodedAccountId}/teams")" class="govuk-link">Return to my account</a>
+                    <a href="@LinkGenerator.AccountsLink($"accounts/{Model.EncodedAccountId}/teams")" class="govuk-link">Continue to my account</a>
                 </p>
 
             </div>

--- a/src/SFA.DAS.LevyTransferMatching.Web/Views/Applications/Withdrawn.cshtml
+++ b/src/SFA.DAS.LevyTransferMatching.Web/Views/Applications/Withdrawn.cshtml
@@ -1,5 +1,8 @@
-﻿@{
-    ViewData["Title"] = "You have withdrawn your application";
+﻿@model SFA.DAS.LevyTransferMatching.Web.Models.Applications.WithdrawnViewModel
+@inject SFA.DAS.EmployerUrlHelper.ILinkGenerator LinkGenerator
+
+@{
+    ViewData["Title"] = "You have successfully withdrawn your application";
 }
 
 <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content">
@@ -9,11 +12,23 @@
             <div class="govuk-grid-column-two-thirds">
 
                 <div class="govuk-panel govuk-panel--confirmation application-complete govuk-!-margin-bottom-9">
-                    <h1 class="govuk-panel__title">You have withdrawn your application</h1>
+                    <h1 class="govuk-panel__title">You have successfully withdrawn your application</h1>
                 </div>
+
+                <h2 class="govuk-heading-m ">What happens next</h2>
+
+                <p class="govuk-!-margin-bottom-0">Your application to <strong>@Model.EmployerNameAndReference</strong> has been withdrawn. You can apply to another opportunity.</p>
+
+                <p class="govuk-!-margin-top-1">
+                    <a href="@Url.Action("Index", "Opportunities")" class="govuk-link">View other opportunities</a>
+                    <br>
+                    or
+                    <br>
+                    <a href="@LinkGenerator.AccountsLink($"accounts/{Model.EncodedAccountId}/teams")" class="govuk-link">Return to my account</a>
+                </p>
 
             </div>
         </div>
 
     </div>
-</main>
+</main> 


### PR DESCRIPTION
Provides the UI/web aspects for the confirmation page when withdrawing an ongoing application.

Note: currently targets `TM-46_withdraw_application`.

See also:

* https://github.com/SkillsFundingAgency/das-apim-endpoints/pull/540