### PR TITLE
#TM-178-(JavaScript is disabled)-Chrome automatically fills location data 

### DIFF
--- a/src/SFA.DAS.LevyTransferMatching.Web/Views/Pledges/Location.cshtml
+++ b/src/SFA.DAS.LevyTransferMatching.Web/Views/Pledges/Location.cshtml
@@ -29,7 +29,7 @@
                                 Additional city or town
                             </label>
                             <span class="govuk-error-message">@Html.ValidationMessageFor(x => x.Locations[i])</span>
-                            <input class="govuk-input app-location-autocomplete" type="text" asp-for="Locations[i]" das-highlight-error-for="Locations[i]" error-class="govuk-input--error" autocomplete="off" />
+                            <input class="govuk-input app-location-autocomplete" type="text" asp-for="Locations[i]" das-highlight-error-for="Locations[i]" error-class="govuk-input--error" autocomplete="disabled" />
                         </div>
                     }
                 </fieldset>


### PR DESCRIPTION
[When JavaScript is disabled] - When creating a new pledge the auto complete automatically fills the location data in all the additional location text boxes. To fixed that we have added  autocomplete="disabled" to the HTML side of the code and it stops this behaviour of the Chrome browser.