### PR TITLE
#TM-176- (When JavaScript is disabled) - When creating a new pledge

### DIFF
--- a/src/SFA.DAS.LevyTransferMatching.Web/Views/Pledges/Location.cshtml
+++ b/src/SFA.DAS.LevyTransferMatching.Web/Views/Pledges/Location.cshtml
@@ -29,7 +29,7 @@
                                 Additional city or town
                             </label>
                             <span class="govuk-error-message">@Html.ValidationMessageFor(x => x.Locations[i])</span>
-                            <input class="govuk-input app-location-autocomplete" type="text" asp-for="Locations[i]" das-highlight-error-for="Locations[i]" error-class="govuk-input--error" autocomplete="off" />
+                            <input class="govuk-input app-location-autocomplete" type="text" asp-for="Locations[i]" das-highlight-error-for="Locations[i]" error-class="govuk-input--error" autocomplete="disabled" />
                         </div>
                     }
                 </fieldset>


### PR DESCRIPTION
#TM-176 When creating a new pledge and JavaScript is disabled, the Chrome browser auto-fills all the locations textboxes. This is resolved by adding autocomplete = "disabled" property of the textboxes. 